### PR TITLE
feat: Add MovieDetails unit tests and E2E test setup

### DIFF
--- a/MovieFinder/MovieFinder.xcodeproj/project.pbxproj
+++ b/MovieFinder/MovieFinder.xcodeproj/project.pbxproj
@@ -28,6 +28,17 @@
 		3F11D0C42D3C7B1E00876A8A /* GenresData.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F11D0C32D3C7AE300876A8A /* GenresData.json */; };
 		3F11D0C62D3C7B4E00876A8A /* MovieDetailsData.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F11D0C52D3C7B3000876A8A /* MovieDetailsData.json */; };
 		3F11D0C82D3C7B9300876A8A /* SimilarMoviesData.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F11D0C72D3C7B7400876A8A /* SimilarMoviesData.json */; };
+		3F535AAB2E69D3170020EA95 /* JSONMockLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AAA2E69D3170020EA95 /* JSONMockLoader.swift */; };
+		3F535AAD2E69E7860020EA95 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AAC2E69E7860020EA95 /* NetworkError.swift */; };
+		3F535AAF2E69E7A40020EA95 /* MockLoaderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AAE2E69E7A40020EA95 /* MockLoaderError.swift */; };
+		3F535AB12E6A189C0020EA95 /* MovieDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AB02E6A189C0020EA95 /* MovieDetailsViewModelTests.swift */; };
+		3F535AB62E76FDC10020EA95 /* MovieDetailsViewModelDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AB52E76FDC10020EA95 /* MovieDetailsViewModelDelegateSpy.swift */; };
+		3F535AB82E7858AC0020EA95 /* HomeScreenPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AB72E7858AC0020EA95 /* HomeScreenPage.swift */; };
+		3F535ABE2E78591E0020EA95 /* MovieDetailsScreenPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535ABD2E78591E0020EA95 /* MovieDetailsScreenPage.swift */; };
+		3F535AC12E785C390020EA95 /* MoviePosterTableViewCellPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AC02E785C390020EA95 /* MoviePosterTableViewCellPage.swift */; };
+		3F535AC32E785C590020EA95 /* MovieHeaderTableViewCellPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AC22E785C590020EA95 /* MovieHeaderTableViewCellPage.swift */; };
+		3F535AC52E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AC42E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift */; };
+		3F535AC72E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift in Resources */ = {isa = PBXBuildFile; fileRef = 3F535AC62E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift */; };
 		3F601DDB2D3F15FC004F08AF /* CustomAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F601DDA2D3F15F8004F08AF /* CustomAlert.swift */; };
 		3F601DDE2D3F1D50004F08AF /* DevelopmentServiceFactory.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F601DDD2D3F1D4C004F08AF /* DevelopmentServiceFactory.swift.swift */; };
 		3F601DE02D3F1D58004F08AF /* ProductionServiceFactory.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F601DDF2D3F1D57004F08AF /* ProductionServiceFactory.swift.swift */; };
@@ -99,6 +110,17 @@
 		3F11D0C32D3C7AE300876A8A /* GenresData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = GenresData.json; sourceTree = "<group>"; };
 		3F11D0C52D3C7B3000876A8A /* MovieDetailsData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MovieDetailsData.json; sourceTree = "<group>"; };
 		3F11D0C72D3C7B7400876A8A /* SimilarMoviesData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SimilarMoviesData.json; sourceTree = "<group>"; };
+		3F535AAA2E69D3170020EA95 /* JSONMockLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONMockLoader.swift; sourceTree = "<group>"; };
+		3F535AAC2E69E7860020EA95 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		3F535AAE2E69E7A40020EA95 /* MockLoaderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLoaderError.swift; sourceTree = "<group>"; };
+		3F535AB02E6A189C0020EA95 /* MovieDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailsViewModelTests.swift; sourceTree = "<group>"; };
+		3F535AB52E76FDC10020EA95 /* MovieDetailsViewModelDelegateSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailsViewModelDelegateSpy.swift; sourceTree = "<group>"; };
+		3F535AB72E7858AC0020EA95 /* HomeScreenPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenPage.swift; sourceTree = "<group>"; };
+		3F535ABD2E78591E0020EA95 /* MovieDetailsScreenPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailsScreenPage.swift; sourceTree = "<group>"; };
+		3F535AC02E785C390020EA95 /* MoviePosterTableViewCellPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviePosterTableViewCellPage.swift; sourceTree = "<group>"; };
+		3F535AC22E785C590020EA95 /* MovieHeaderTableViewCellPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieHeaderTableViewCellPage.swift; sourceTree = "<group>"; };
+		3F535AC42E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarMovieTableViewCellPage.swift; sourceTree = "<group>"; };
+		3F535AC62E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeToMovieDetailsE2ETests.swift; sourceTree = "<group>"; };
 		3F601DDA2D3F15F8004F08AF /* CustomAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlert.swift; sourceTree = "<group>"; };
 		3F601DDD2D3F1D4C004F08AF /* DevelopmentServiceFactory.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevelopmentServiceFactory.swift.swift; sourceTree = "<group>"; };
 		3F601DDF2D3F1D57004F08AF /* ProductionServiceFactory.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionServiceFactory.swift.swift; sourceTree = "<group>"; };
@@ -189,6 +211,67 @@
 			path = MockServices;
 			sourceTree = "<group>";
 		};
+		3F535AB22E6A18B60020EA95 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				3F535AB32E6A18C60020EA95 /* MovieDetails */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		3F535AB32E6A18C60020EA95 /* MovieDetails */ = {
+			isa = PBXGroup;
+			children = (
+				3F535AB52E76FDC10020EA95 /* MovieDetailsViewModelDelegateSpy.swift */,
+				3F535AB42E6A18EB0020EA95 /* ViewModel */,
+			);
+			path = MovieDetails;
+			sourceTree = "<group>";
+		};
+		3F535AB42E6A18EB0020EA95 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				3F535AB02E6A189C0020EA95 /* MovieDetailsViewModelTests.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		3F535ABA2E7858BD0020EA95 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				3F535ABB2E7858D50020EA95 /* Home */,
+				3F535ABC2E7858EE0020EA95 /* MovieDetails */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		3F535ABB2E7858D50020EA95 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				3F535AB72E7858AC0020EA95 /* HomeScreenPage.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		3F535ABC2E7858EE0020EA95 /* MovieDetails */ = {
+			isa = PBXGroup;
+			children = (
+				3F535ABF2E785C200020EA95 /* Cells */,
+				3F535ABD2E78591E0020EA95 /* MovieDetailsScreenPage.swift */,
+			);
+			path = MovieDetails;
+			sourceTree = "<group>";
+		};
+		3F535ABF2E785C200020EA95 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				3F535AC22E785C590020EA95 /* MovieHeaderTableViewCellPage.swift */,
+				3F535AC02E785C390020EA95 /* MoviePosterTableViewCellPage.swift */,
+				3F535AC42E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
 		3F601DDC2D3F1D3A004F08AF /* ServiceFactories */ = {
 			isa = PBXGroup;
 			children = (
@@ -245,6 +328,7 @@
 			isa = PBXGroup;
 			children = (
 				3FD628582D3BE9420059116F /* MovieFinderTests.swift */,
+				3F535AB22E6A18B60020EA95 /* Sources */,
 			);
 			path = MovieFinderTests;
 			sourceTree = "<group>";
@@ -252,8 +336,10 @@
 		3FD6285D2D3BE9440059116F /* MovieFinderUITests */ = {
 			isa = PBXGroup;
 			children = (
+				3F535AC62E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift */,
 				3FD6285B2D3BE9440059116F /* MovieFinderUITests.swift */,
 				3FD6285C2D3BE9440059116F /* MovieFinderUITestsLaunchTests.swift */,
+				3F535ABA2E7858BD0020EA95 /* Sources */,
 			);
 			path = MovieFinderUITests;
 			sourceTree = "<group>";
@@ -331,6 +417,8 @@
 		3FD628672D3BE9E00059116F /* Type */ = {
 			isa = PBXGroup;
 			children = (
+				3F535AAE2E69E7A40020EA95 /* MockLoaderError.swift */,
+				3F535AAC2E69E7860020EA95 /* NetworkError.swift */,
 				3F626FD42D41A6F600BC188D /* TMDBImageSize.swift */,
 				3F626FD62D41AB3D00BC188D /* TMDBImagePath.swift */,
 				3FD4C8542D3C959A005BBB3F /* SystemImage.swift */,
@@ -389,6 +477,7 @@
 		3FD6286D2D3BEA410059116F /* MoviesService */ = {
 			isa = PBXGroup;
 			children = (
+				3F535AAA2E69D3170020EA95 /* JSONMockLoader.swift */,
 				3FD6289E2D3C48590059116F /* APIKeys.swift */,
 				3FD628A02D3C488B0059116F /* JSONFile.swift */,
 				3F11D0B92D3C759100876A8A /* APIServices */,
@@ -600,6 +689,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F535AC72E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -619,6 +709,8 @@
 				3FD6288E2D3C0D2E0059116F /* AppConfig.swift in Sources */,
 				3F601DDB2D3F15FC004F08AF /* CustomAlert.swift in Sources */,
 				3FD628992D3C3C6C0059116F /* MovieDetailsScreen.swift in Sources */,
+				3F535AAF2E69E7A40020EA95 /* MockLoaderError.swift in Sources */,
+				3F535AAD2E69E7860020EA95 /* NetworkError.swift in Sources */,
 				3FD628A12D3C488B0059116F /* JSONFile.swift in Sources */,
 				3F626FD52D41A75800BC188D /* TMDBImageSize.swift in Sources */,
 				3F11D0AD2D3C6C4700876A8A /* MovieDetailsServiceManager.swift in Sources */,
@@ -641,6 +733,7 @@
 				3FD4C8572D3C98D8005BBB3F /* StatsView.swift in Sources */,
 				3FD6289B2D3C3C880059116F /* MovieDetailsVC.swift in Sources */,
 				3F11D0A72D3C5FF500876A8A /* Genre.swift in Sources */,
+				3F535AAB2E69D3170020EA95 /* JSONMockLoader.swift in Sources */,
 				3FD628882D3BEFCE0059116F /* HomeScreen.swift in Sources */,
 				3FD6288C2D3C0A0B0059116F /* String+Extensions.swift in Sources */,
 				3FD6287E2D3BEECA0059116F /* ViewCode.swift in Sources */,
@@ -659,7 +752,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F535AB12E6A189C0020EA95 /* MovieDetailsViewModelTests.swift in Sources */,
 				3FD6285A2D3BE9420059116F /* MovieFinderTests.swift in Sources */,
+				3F535AB62E76FDC10020EA95 /* MovieDetailsViewModelDelegateSpy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -667,8 +762,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F535AC52E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift in Sources */,
 				3FD6285E2D3BE9440059116F /* MovieFinderUITests.swift in Sources */,
+				3F535AC32E785C590020EA95 /* MovieHeaderTableViewCellPage.swift in Sources */,
+				3F535AB82E7858AC0020EA95 /* HomeScreenPage.swift in Sources */,
+				3F535ABE2E78591E0020EA95 /* MovieDetailsScreenPage.swift in Sources */,
 				3FD6285F2D3BE9440059116F /* MovieFinderUITestsLaunchTests.swift in Sources */,
+				3F535AC12E785C390020EA95 /* MoviePosterTableViewCellPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MovieFinder/MovieFinder/Aplication/SceneDelegate.swift
+++ b/MovieFinder/MovieFinder/Aplication/SceneDelegate.swift
@@ -20,7 +20,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let window = UIWindow(windowScene: windowScene)
         
-        let navigationController = UINavigationController(rootViewController: HomeVC())
+        let homeViewModel: HomeViewModel = HomeViewModel()
+        let navigationController = UINavigationController(rootViewController: HomeVC(viewModel: homeViewModel))
         
         window.rootViewController = navigationController
         

--- a/MovieFinder/MovieFinder/Model/Genre.swift
+++ b/MovieFinder/MovieFinder/Model/Genre.swift
@@ -15,9 +15,28 @@ struct GenreResponse: Codable {
         case genres
     }
     
+    init(
+        genres: [Genre]
+    ) {
+        self.genres = genres
+    }
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         genres = try container.decodeIfPresent([Genre].self, forKey: .genres) ?? []
+    }
+}
+
+extension GenreResponse {
+    static func with(
+        genreResponse: GenreResponse = GenreResponse(
+            genres: [Genre(id: 28, name: "Ação"),
+                     Genre(id: 12, name: "Aventura"),
+                     Genre(id: 16, name: "Animação"),
+                     Genre(id: 35, name: "Comédia")]
+        )
+    ) -> GenreResponse {
+        return genreResponse
     }
 }
 
@@ -31,9 +50,25 @@ struct Genre: Codable {
         case name
     }
     
+    init(
+        id: Int,
+        name: String
+    ) {
+        self.id = id
+        self.name = name
+    }
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decodeIfPresent(Int.self, forKey: .id) ?? 0
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? "Unknown"
+    }
+}
+
+extension Genre {
+    static func with(
+        genre: Genre = Genre(id: 28, name: "Ação")
+    ) -> Genre {
+        return genre
     }
 }

--- a/MovieFinder/MovieFinder/Model/Movie.swift
+++ b/MovieFinder/MovieFinder/Model/Movie.swift
@@ -33,6 +33,27 @@ struct Movie: Decodable {
         case voteCount = "vote_count"
     }
     
+    init(
+        backdropPath: String,
+        genreIDs: [Int]?,
+        id: Int,
+        popularity: Double,
+        posterPath: String,
+        releaseDate: String,
+        title: String,
+        voteCount: Int
+    ) {
+        self.backdropPath = backdropPath
+        self.genreIDs = genreIDs
+        self.id = id
+        self.popularity = popularity
+        self.posterPath = posterPath
+        self.releaseDate = releaseDate
+        self.title = title
+        self.voteCount = voteCount
+    }
+    
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         backdropPath = try container.decodeIfPresent(String.self, forKey: .backdropPath) ?? ""
@@ -50,18 +71,6 @@ struct Movie: Decodable {
         }
     }
     
-    /// Generates the complete URL for the movie's image based on its type (poster or backdrop).
-    ///
-    /// This function combines the base image URL, a specified image size, and the corresponding image path (either `backdropPath` or `posterPath`) of the movie.
-    ///
-    /// - Parameters:
-    ///   - size: The desired image size. The default value is `.w185`, which corresponds to a specific image resolution.
-    ///   - pathImage: The type of image path to use, either `.backdropPath` or `.posterPath`. The default is `.posterPath`.
-    ///
-    /// - Note: If the specified image path is empty, the function will return an empty string.
-    /// - Note: The image size is currently hardcoded as `w185`, but it can be changed by passing a different value to the `size` parameter.
-    ///
-    /// - Returns: A `String` representing the complete URL to access the movie's image. Returns an empty string if the image path is empty.
     func imageURL(size: TMDBImageSize = .w185, pathImage: TMDBImagePath = .posterPath) -> String {
         switch pathImage {
         case .backdropPath:
@@ -81,15 +90,6 @@ struct Movie: Decodable {
         return releaseDate.extractYear(fromFormat: "yyyy-MM-dd")
     }
     
-    /// Translates genre IDs to their corresponding genre names.
-    ///
-    /// This function takes a dictionary mapping genre IDs to their corresponding genre names and returns a `String`
-    /// containing the genre names associated with the first two genre IDs in the given array. If the `genreIDs`
-    /// property is `nil` or empty, it returns an error message.
-    ///
-    /// - Parameter mappingGenres: A dictionary where the keys are `Int` genre IDs and the values are `String` genre names.
-    /// - Returns: A `String` representing the genre names associated with the first two genre IDs. If only one genre ID
-    ///   exists, it returns the name of that genre. If no genre IDs exist, it returns `"Error"`.
     func genreNames(using mappingGenres: [Int: String]) -> String {
         guard let genreIDs = self.genreIDs, !genreIDs.isEmpty else {
             return ""
@@ -101,5 +101,21 @@ struct Movie: Decodable {
             let genres = genreIDs.prefix(2).compactMap { mappingGenres[$0] }
             return "\(genres[0]), \(genres[1])"
         }
+    }
+}
+
+extension Movie {
+    static func with(
+        movie: Movie = Movie(
+            backdropPath: "/zOpe0eHsq0A2NvNyBbtT6sj53qV.jpg",
+            genreIDs: [16, 12, 14],
+            id: 939243,
+            popularity: 2596.305,
+            posterPath: "/8HzA55GCjRTEC2YhPGna8Lc8qHo.jpg",
+            releaseDate: "2024-12-19",
+            title: "Sonic 3: O Filme",
+            voteCount: 638)
+    ) -> Movie {
+        return movie
     }
 }

--- a/MovieFinder/MovieFinder/Resources/Type/MockLoaderError.swift
+++ b/MovieFinder/MovieFinder/Resources/Type/MockLoaderError.swift
@@ -1,0 +1,22 @@
+//
+//  MockLoaderError.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 04/09/25.
+//
+
+import Foundation
+
+enum MockLoaderError: Error, LocalizedError {
+    case fileNotFound(String)
+    case decodingError
+    
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let filename):
+            return "Mock file not found: \(filename).json"
+        case .decodingError:
+            return "Failed to decode mock file."
+        }
+    }
+}

--- a/MovieFinder/MovieFinder/Resources/Type/NetworkError.swift
+++ b/MovieFinder/MovieFinder/Resources/Type/NetworkError.swift
@@ -1,0 +1,37 @@
+//
+//  NetworkError.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 04/09/25.
+//
+
+import Foundation
+
+enum NetworkError: Error, LocalizedError {
+    case noInternet
+    case timeout
+    case invalidURL
+    case urlComponentCreationFailed
+    case serverError(code: Int)
+    case decodingError
+    case unknown(description: String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .noInternet:
+            return "No internet connection."
+        case .timeout:
+            return "The request timed out."
+        case .invalidURL:
+            return "Invalid URL."
+        case .urlComponentCreationFailed:
+            return "Failed to construct URL with components."
+        case .serverError(let code):
+            return "Server error (\(code))."
+        case .decodingError:
+            return "Failed to decode mock file."
+        case .unknown(let description):
+            return description
+        }
+    }
+}

--- a/MovieFinder/MovieFinder/Service/MoviesService/APIServices/GenreServiceManager.swift
+++ b/MovieFinder/MovieFinder/Service/MoviesService/APIServices/GenreServiceManager.swift
@@ -8,15 +8,14 @@
 import Foundation
 
 final class GenreServiceManager: TMDBService, GenreServiceProtocol {
-    /// Fetches the genres of movies from the API.
-    ///
-    /// - Parameter language: A string representing the language for the genre list.
-    /// - Returns: A `GenreResponse` object containing the fetched genres.
-    /// - Throws: An error of type `MoviesLoadingError` if the URL is invalid or if an error occurs during the request.
     func fetchGenres(language: String) async throws -> GenreResponse {
-        guard let url = URL(string: "https://api.themoviedb.org/3/genre/movie/list") else { throw MoviesLoadingError.errorReceivingData }
+        guard let url = URL(string: "https://api.themoviedb.org/3/genre/movie/list") else {
+            throw NetworkError.invalidURL
+        }
         
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { throw MoviesLoadingError.errorReceivingData }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            throw NetworkError.invalidURL
+        }
         
         let queryItems: [URLQueryItem] = [
             URLQueryItem(name: "language", value: language),

--- a/MovieFinder/MovieFinder/Service/MoviesService/APIServices/MovieDetailsServiceManager.swift
+++ b/MovieFinder/MovieFinder/Service/MoviesService/APIServices/MovieDetailsServiceManager.swift
@@ -8,17 +8,14 @@
 import Foundation
 
 final class MovieDetailsServiceManager: TMDBService, MovieDetailsServiceProtocol {
-    /// Fetches the details of a movie from the API.
-    ///
-    /// - Parameters:
-    ///   - movieId: An integer representing the unique identifier of the movie.
-    ///   - language: A string representing the language for the movie details.
-    /// - Returns: A `Movie` object containing the fetched movie details.
-    /// - Throws: An error of type `MoviesLoadingError` if the URL is invalid or if an error occurs during the request.
     func fetchMovieDetails(movieId: Int, language: String) async throws -> Movie {
-        guard let url = URL(string: "https://api.themoviedb.org/3/movie/\(movieId)") else { throw MoviesLoadingError.errorReceivingData }
+        guard let url = URL(string: "https://api.themoviedb.org/3/movie/\(movieId)") else {
+            throw NetworkError.invalidURL
+        }
         
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { throw MoviesLoadingError.errorReceivingData }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            throw NetworkError.urlComponentCreationFailed
+        }
         
         let queryItems: [URLQueryItem] = [
             URLQueryItem(name: "language", value: language),

--- a/MovieFinder/MovieFinder/Service/MoviesService/APIServices/SimilarMoviesServiceManager.swift
+++ b/MovieFinder/MovieFinder/Service/MoviesService/APIServices/SimilarMoviesServiceManager.swift
@@ -8,17 +8,14 @@
 import Foundation
 
 final class SimilarMoviesServiceManager: TMDBService, SimilarMoviesServiceProtocol {
-    /// Fetches a list of movies related to a specified movie from the API.
-    ///
-    /// - Parameters:
-    ///   - movieId: An integer representing the unique identifier of the movie for which similar movies are to be fetched.
-    ///   - language: A string representing the language for the related movie details.
-    /// - Returns: A `MovieResponse` object containing the fetched related movies.
-    /// - Throws: An error of type `MoviesLoadingError` if the URL is invalid or if an error occurs during the request.
     func fetchRelatedMovies(movieId: Int, language: String) async throws -> MovieResponse {
-        guard let url = URL(string: "https://api.themoviedb.org/3/movie/\(movieId)/similar") else { throw MoviesLoadingError.errorReceivingData }
+        guard let url = URL(string: "https://api.themoviedb.org/3/movie/\(movieId)/similar") else {
+            throw NetworkError.invalidURL
+        }
         
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { throw MoviesLoadingError.errorReceivingData }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            throw NetworkError.invalidURL
+        }
         
         let queryItems: [URLQueryItem] = [
             URLQueryItem(name: "language", value: language),

--- a/MovieFinder/MovieFinder/Service/MoviesService/JSONMockLoader.swift
+++ b/MovieFinder/MovieFinder/Service/MoviesService/JSONMockLoader.swift
@@ -1,0 +1,38 @@
+//
+//  JSONMockLoader.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 04/09/25.
+//
+
+import Foundation
+
+protocol MockLoaderProtocol {
+    func load<T: Decodable>(_ filename: String, as type: T.Type) throws -> T
+}
+
+class DefaultJSONMockLoader: MockLoaderProtocol {
+    private let bundle: Bundle
+    private let decoderService: JSONDecoderService
+    
+    init(bundle: Bundle = .main,
+         decoderService: JSONDecoderService = JSONDecoderService()) {
+        self.bundle = bundle
+        self.decoderService = decoderService
+    }
+    
+    func load<T>(_ filename: String, as type: T.Type) throws -> T where T : Decodable {
+        guard let url = bundle.url(forResource: filename, withExtension: "json") else {
+            throw MockLoaderError.fileNotFound(filename)
+        }
+        
+        do {
+            let data = try Data(contentsOf: url)
+            return try decoderService.decode(T.self, from: data)
+        } catch is DecodingError {
+            throw MockLoaderError.decodingError
+        } catch {
+            throw NetworkError.unknown(description: error.localizedDescription)
+        }
+    }
+}

--- a/MovieFinder/MovieFinder/Service/MoviesService/MockServices/MockGenreService.swift
+++ b/MovieFinder/MovieFinder/Service/MoviesService/MockServices/MockGenreService.swift
@@ -8,32 +8,24 @@
 import Foundation
 
 final class MockGenreService: GenreServiceProtocol {
-    private let decoderService: JSONDecoderService
+    var result: Result<GenreResponse, Error>
     
-    init(decoderService: JSONDecoderService = JSONDecoderService()) {
-        self.decoderService = decoderService
+    init(result: Result<GenreResponse, Error>) {
+        self.result = result
     }
     
-    // Fetches genres from a local JSON file for testing or mocking purposes.
-    ///
-    /// - Parameter language: A string representing the language for the genre list (not used in this implementation).
-    /// - Returns: A `GenreResponse` object containing the fetched genres.
-    /// - Throws: An error of type `GenreLoadingError` if the JSON file cannot be found or if an error occurs during data loading or decoding.
-    func fetchGenres(language: String) async throws -> GenreResponse {
-        guard let url = Bundle.main.url(forResource: JSONFile.genresData.rawValue, withExtension: JSONFile.json.rawValue) else { throw GenreLoadingError.errorReceivingData }
-        
+    convenience init() {
         do {
-            let data = try Data(contentsOf: url)
-            let genres: GenreResponse = try decoderService.decode(GenreResponse.self, from: data)
-            return genres
+            let genres = try DefaultJSONMockLoader().load(
+                JSONFile.genresData.rawValue,
+                as: GenreResponse.self)
+            self.init(result: .success(genres))
         } catch {
-            print("Error: \(error.localizedDescription)")
-            throw error
+            self.init(result: .failure(error))
         }
     }
-}
-
-// Enum that represents the possible errors that may occur when loading an gender
-enum GenreLoadingError: Swift.Error {
-    case errorReceivingData
+    
+    public func fetchGenres(language: String) async throws -> GenreResponse {
+        return try result.get()
+    }
 }

--- a/MovieFinder/MovieFinder/Sources/Home/View/HomeVC.swift
+++ b/MovieFinder/MovieFinder/Sources/Home/View/HomeVC.swift
@@ -8,9 +8,19 @@
 import UIKit
 
 class HomeVC: UIViewController {
-    
-    var viewModel: HomeViewModel = HomeViewModel()
+    let viewModel: HomeViewModel
     var screen: HomeScreen?
+    
+    init(viewModel: HomeViewModel = HomeViewModel(),
+         screen: HomeScreen? = HomeScreen()) {
+        self.viewModel = viewModel
+        self.screen = screen
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,7 +54,8 @@ extension HomeVC: HomeScreenDelegate {
     /// This method instantiates the `MovieDetailsVC` and pushes it onto the navigation stack,
     /// allowing the user to view details about a selected movie.
     func didTapWelcomeButton() {
-        let movieDetailsVC = MovieDetailsVC()
+        let movieDetailsViewModel: MovieDetailsViewModelProtocol = MovieDetailsViewModel()
+        let movieDetailsVC = MovieDetailsVC(viewModel: movieDetailsViewModel)
         navigationController?.pushViewController(movieDetailsVC, animated: true)
     }
 }
@@ -54,4 +65,3 @@ extension HomeVC: HomeViewModelDelegate {
         screen?.setupTitles(viewModel.welcomeLabelText, viewModel.welcomeButtonTitle)
     }
 }
-

--- a/MovieFinder/MovieFinderTests/Sources/MovieDetails/MovieDetailsViewModelDelegateSpy.swift
+++ b/MovieFinder/MovieFinderTests/Sources/MovieDetails/MovieDetailsViewModelDelegateSpy.swift
@@ -1,0 +1,45 @@
+//
+//  MovieDetailsViewModelDelegateSpy.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 14/09/25.
+//
+
+import XCTest
+@testable import MovieFinder
+
+class MovieDetailsViewModelDelegateSpy: MovieDetailsViewModelDelegate {
+    private(set) var loadMovieDetailsSuccessCallCount = 0
+    private(set) var receivedMovieDetails: Movie?
+    
+    private(set) var loadGenresAndSimilarMoviesSuccessCallCount = 0
+    private(set) var receivedGenresDictionary: [Int : String]?
+    private(set) var receivedSimilarMovies: [Movie]?
+    private(set) var receivedIndexPath: [IndexPath]?
+    
+    private(set) var errorLoadingDataCallCount = 0
+    private(set) var receivedErrorMessage: String?
+    
+    private(set) var showNoSimilarMoviesFoundCallCount = 0
+    
+    func errorLoadingData(message: String) {
+        errorLoadingDataCallCount += 1
+        receivedErrorMessage = message
+    }
+    
+    func loadMovieDetailsSuccess(movieDetails: Movie?) {
+        loadMovieDetailsSuccessCallCount += 1
+        receivedMovieDetails = movieDetails
+    }
+    
+    func loadGenresAndSimilarMoviesSuccess(genresDictionary: [Int : String], similarMovies: [Movie], _ indexPath: [IndexPath]) {
+        loadGenresAndSimilarMoviesSuccessCallCount += 1
+        receivedGenresDictionary = genresDictionary
+        receivedSimilarMovies = similarMovies
+        receivedIndexPath = indexPath
+    }
+    
+    func showNoSimilarMoviesFound() {
+        showNoSimilarMoviesFoundCallCount += 1
+    }
+}

--- a/MovieFinder/MovieFinderTests/Sources/MovieDetails/ViewModel/MovieDetailsViewModelTests.swift
+++ b/MovieFinder/MovieFinderTests/Sources/MovieDetails/ViewModel/MovieDetailsViewModelTests.swift
@@ -1,0 +1,210 @@
+//
+//  MovieDetailsViewModelTests.swift
+//  MovieFinderTests
+//
+//  Created by Bruno Moura on 04/09/25.
+//
+
+import XCTest
+@testable import MovieFinder
+
+final class MovieDetailsViewModelTests: XCTestCase {
+    
+    private var genreServiceMock: MockGenreService!
+    private var movieDetailsServiceMock: MockMovieDetailsService!
+    private var similarMoviesServiceMock: MockSimilarMoviesService!
+    
+    private var delegateSpy: MovieDetailsViewModelDelegateSpy!
+    private var sut: MovieDetailsViewModel!
+    
+    override func setUp() {
+        super.setUp()
+        genreServiceMock = MockGenreService()
+        movieDetailsServiceMock = MockMovieDetailsService()
+        similarMoviesServiceMock = MockSimilarMoviesService()
+        delegateSpy = MovieDetailsViewModelDelegateSpy()
+        
+        sut = MovieDetailsViewModel(
+            genreServiceProtocol: genreServiceMock,
+            movieDetailsServiceProtocol: movieDetailsServiceMock,
+            similarMoviesServiceProtocol: similarMoviesServiceMock
+        )
+        sut.delegate = delegateSpy
+    }
+    
+    override func tearDown() {
+        genreServiceMock = nil
+        movieDetailsServiceMock = nil
+        similarMoviesServiceMock = nil
+        delegateSpy = nil
+        sut = nil
+        super.tearDown()
+    }
+    
+    func test_loadMovieDetails_shouldToggleIsLoadingProperly() async {
+        // Arrange
+        let dummyMovie = Movie.with()
+        movieDetailsServiceMock.result = .success(dummyMovie)
+        
+        // Act
+        await sut.loadMovieDetails()
+        
+        // Assert
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertEqual(delegateSpy.loadMovieDetailsSuccessCallCount, 1)
+    }
+    
+    func test_loadMovieDetails_whenServiceReturnsSuccess_shouldCallDelegateWithMovie() async {
+        // Arrange
+        let dummyMovie = Movie.with()
+        movieDetailsServiceMock.result = .success(dummyMovie)
+        
+        // Act
+        await sut.loadMovieDetails()
+        
+        // Assert
+        XCTAssertEqual(delegateSpy.loadMovieDetailsSuccessCallCount, 1)
+        XCTAssertNotNil(delegateSpy.receivedMovieDetails)
+        XCTAssertEqual(delegateSpy.receivedMovieDetails?.id, 939243)
+        XCTAssertEqual(delegateSpy.errorLoadingDataCallCount, 0)
+    }
+    
+    func test_loadMovieDetails_whenServiceThrowsError_shouldCallDelegateWithError() async {
+        // Arrange
+        let expectedError = NetworkError.noInternet
+        movieDetailsServiceMock.result = .failure(expectedError)
+        
+        // Act
+        await sut.loadMovieDetails()
+        
+        // Assert
+        XCTAssertEqual(delegateSpy.errorLoadingDataCallCount, 1)
+        XCTAssertEqual(delegateSpy.receivedErrorMessage, expectedError.localizedDescription)
+        XCTAssertEqual(delegateSpy.loadMovieDetailsSuccessCallCount, 0)
+    }
+    
+    
+    func test_loadGenresAndSimilarMovies_shouldToggleIsLoadingProperly() async {
+        // Arrange
+        let dummyGenres = GenreResponse.with()
+        let dummySimilarMovies = MovieResponse(results: [Movie.with(), Movie.with()])
+        
+        genreServiceMock.result = .success(dummyGenres)
+        similarMoviesServiceMock.result = .success(dummySimilarMovies)
+        
+        // Act
+        await sut.loadGenresAndSimilarMovies()
+        
+        // Assert
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertEqual(delegateSpy.loadGenresAndSimilarMoviesSuccessCallCount, 1)
+    }
+    
+    func test_loadGenresAndSimilarMovies_whenServicesReturnSuccess_shouldCallDelegateWithData() async {
+        // Arrange
+        let dummyGenres = GenreResponse.with()
+        let dummySimilarMovies = MovieResponse(results: [Movie.with(), Movie.with()])
+        
+        genreServiceMock.result = .success(dummyGenres)
+        similarMoviesServiceMock.result = .success(dummySimilarMovies)
+        
+        // Act
+        await sut.loadGenresAndSimilarMovies()
+        
+        // Assert
+        XCTAssertEqual(delegateSpy.receivedGenresDictionary?[28], "Ação")
+        XCTAssertEqual(delegateSpy.receivedGenresDictionary?[12], "Aventura")
+        XCTAssertEqual(delegateSpy.receivedGenresDictionary?[16], "Animação")
+        XCTAssertEqual(delegateSpy.receivedGenresDictionary?[35], "Comédia")
+        XCTAssertEqual(delegateSpy.receivedGenresDictionary?.count, 4)
+        XCTAssertEqual(delegateSpy.receivedIndexPath, [IndexPath(row: 2, section: 0), IndexPath(row: 3, section: 0)])
+        XCTAssertEqual(delegateSpy.receivedSimilarMovies?.count, 2)
+        XCTAssertEqual(delegateSpy.receivedSimilarMovies?.first?.id, 939243)
+    }
+    
+    func test_loadGenresAndSimilarMovies_defineIndexPathWithMultipleMovies() async {
+        // Arrange
+        let dummyGenres = GenreResponse.with()
+        let dummySimilarMovies = MovieResponse(results:
+                                                [Movie.with(),
+                                                 Movie(
+                                                    backdropPath: "/g67r1eiQD3ERSEQFCFkSn7TeGw5.jpg",
+                                                    genreIDs: [12],
+                                                    id: 775,
+                                                    popularity: 14.616,
+                                                    posterPath: "/9o0v5LLFk51nyTBHZSre6OB37n2.jpg",
+                                                    releaseDate: "1902-06-21",
+                                                    title: "A Trip to the Moon",
+                                                    voteCount: 1801)])
+        
+        genreServiceMock.result = .success(dummyGenres)
+        similarMoviesServiceMock.result = .success(dummySimilarMovies)
+        
+        // Act
+        await sut.loadGenresAndSimilarMovies()
+        
+        // Assert
+        let expectedIndexPaths = (0..<2).map { IndexPath(row: $0 + 2, section: 0) }
+        XCTAssertEqual(delegateSpy.receivedIndexPath, expectedIndexPaths)
+    }
+    
+    func test_loadGenresAndSimilarMovies_whenSimilarMoviesReturnsEmpty_shouldCallDelegateWithEmptyArray() async {
+        // Arrange
+        let dummyGenres = GenreResponse.with()
+        let emptySimilarMovies = MovieResponse(results: [])
+        
+        genreServiceMock.result = .success(dummyGenres)
+        similarMoviesServiceMock.result = .success(emptySimilarMovies)
+        
+        // Act
+        await sut.loadGenresAndSimilarMovies()
+        
+        // Assert
+        XCTAssertEqual(delegateSpy.showNoSimilarMoviesFoundCallCount, 1)
+        XCTAssertEqual(delegateSpy.loadGenresAndSimilarMoviesSuccessCallCount, 0)
+        XCTAssertEqual(delegateSpy.errorLoadingDataCallCount, 0)
+    }
+    
+    func test_loadGenresAndSimilarMovies_whenSimilarMoviesServiceThrowsError_shouldCallDelegateWithError() async {
+        // Arrange
+        let dummyGenres = GenreResponse.with()
+        let expectedError = NetworkError.serverError(code: 500)
+        
+        genreServiceMock.result = .success(dummyGenres)
+        similarMoviesServiceMock.result = .failure(expectedError)
+        
+        // Act
+        await sut.loadGenresAndSimilarMovies()
+        
+        // Assert
+        XCTAssertEqual(delegateSpy.errorLoadingDataCallCount, 1)
+        XCTAssertEqual(delegateSpy.loadGenresAndSimilarMoviesSuccessCallCount, 0)
+        XCTAssertEqual(delegateSpy.showNoSimilarMoviesFoundCallCount, 0)
+        XCTAssertEqual(delegateSpy.receivedErrorMessage, expectedError.localizedDescription)
+        XCTAssertNil(delegateSpy.receivedGenresDictionary)
+        XCTAssertNil(delegateSpy.receivedSimilarMovies)
+        XCTAssertNil(delegateSpy.receivedIndexPath)
+        XCTAssertFalse(sut.isLoading)
+    }
+    
+    func test_loadGenresAndSimilarMovies_whenGenresServiceThrowsError_shouldCallDelegateWithError() async {
+        // Arrange
+        let expectedError = NetworkError.serverError(code: 500)
+        
+        genreServiceMock.result = .failure(expectedError)
+        similarMoviesServiceMock.result = .success(MovieResponse.init(results: []))
+        
+        // Act
+        await sut.loadGenresAndSimilarMovies()
+        
+        // Assert
+        XCTAssertEqual(delegateSpy.errorLoadingDataCallCount, 1)
+        XCTAssertEqual(delegateSpy.loadMovieDetailsSuccessCallCount, 0)
+        XCTAssertEqual(delegateSpy.receivedErrorMessage, expectedError.localizedDescription)
+        XCTAssertEqual(delegateSpy.showNoSimilarMoviesFoundCallCount, 0)
+        XCTAssertNil(delegateSpy.receivedGenresDictionary)
+        XCTAssertNil(delegateSpy.receivedSimilarMovies)
+        XCTAssertNil(delegateSpy.receivedIndexPath)
+        XCTAssertFalse(sut.isLoading)
+    }
+}

--- a/MovieFinder/MovieFinderUITests/HomeToMovieDetailsE2ETests.swift
+++ b/MovieFinder/MovieFinderUITests/HomeToMovieDetailsE2ETests.swift
@@ -1,0 +1,24 @@
+//
+//  HomeToMovieDetailsE2ETests.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+
+import XCTest
+
+final class HomeToMovieDetailsE2ETests: XCTestCase {
+    
+    private var app: XCUIApplication!
+    
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+    
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+}

--- a/MovieFinder/MovieFinderUITests/Sources/Home/HomeScreenPage.swift
+++ b/MovieFinder/MovieFinderUITests/Sources/Home/HomeScreenPage.swift
@@ -1,0 +1,7 @@
+//
+//  HomeScreenPage.swift
+//  MovieFinderUITests
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+

--- a/MovieFinder/MovieFinderUITests/Sources/MovieDetails/Cells/MovieHeaderTableViewCellPage.swift
+++ b/MovieFinder/MovieFinderUITests/Sources/MovieDetails/Cells/MovieHeaderTableViewCellPage.swift
@@ -1,0 +1,7 @@
+//
+//  MovieHeaderTableViewCellPage.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+

--- a/MovieFinder/MovieFinderUITests/Sources/MovieDetails/Cells/MoviePosterTableViewCellPage.swift
+++ b/MovieFinder/MovieFinderUITests/Sources/MovieDetails/Cells/MoviePosterTableViewCellPage.swift
@@ -1,0 +1,7 @@
+//
+//  MoviePosterTableViewCellPage.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+

--- a/MovieFinder/MovieFinderUITests/Sources/MovieDetails/Cells/SimilarMovieTableViewCellPage.swift
+++ b/MovieFinder/MovieFinderUITests/Sources/MovieDetails/Cells/SimilarMovieTableViewCellPage.swift
@@ -1,0 +1,7 @@
+//
+//  SimilarMovieTableViewCellPage.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+

--- a/MovieFinder/MovieFinderUITests/Sources/MovieDetails/MovieDetailsScreenPage.swift
+++ b/MovieFinder/MovieFinderUITests/Sources/MovieDetails/MovieDetailsScreenPage.swift
@@ -1,0 +1,7 @@
+//
+//  MovieDetailsScreenPage.swift
+//  MovieFinderUITests
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+


### PR DESCRIPTION
- Create unit tests for the `MovieDetailsViewModel`, covering success, failure scenarios, and the delegate's logic.
- Refactor ViewControllers to inject ViewModels via constructor, improving isolation and testability.
- Adjust models and services used by the ViewModel to facilitate mock creation.
- Add initial configuration files and mocks for the future implementation of end-to-end (E2E) tests.