### PR TITLE
Add unit tests for HomeViewModel

### DIFF
--- a/MovieFinder/MovieFinder.xcodeproj/project.pbxproj
+++ b/MovieFinder/MovieFinder.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		3F535AC32E785C590020EA95 /* MovieHeaderTableViewCellPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AC22E785C590020EA95 /* MovieHeaderTableViewCellPage.swift */; };
 		3F535AC52E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AC42E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift */; };
 		3F535AC72E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift in Resources */ = {isa = PBXBuildFile; fileRef = 3F535AC62E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift */; };
+		3F535ACA2E7863E10020EA95 /* HomeViewModelDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535AC92E7863E10020EA95 /* HomeViewModelDelegateSpy.swift */; };
+		3F535ACD2E7864060020EA95 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F535ACC2E7864060020EA95 /* HomeViewModelTests.swift */; };
 		3F601DDB2D3F15FC004F08AF /* CustomAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F601DDA2D3F15F8004F08AF /* CustomAlert.swift */; };
 		3F601DDE2D3F1D50004F08AF /* DevelopmentServiceFactory.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F601DDD2D3F1D4C004F08AF /* DevelopmentServiceFactory.swift.swift */; };
 		3F601DE02D3F1D58004F08AF /* ProductionServiceFactory.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F601DDF2D3F1D57004F08AF /* ProductionServiceFactory.swift.swift */; };
@@ -121,6 +123,8 @@
 		3F535AC22E785C590020EA95 /* MovieHeaderTableViewCellPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieHeaderTableViewCellPage.swift; sourceTree = "<group>"; };
 		3F535AC42E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarMovieTableViewCellPage.swift; sourceTree = "<group>"; };
 		3F535AC62E785D0F0020EA95 /* HomeToMovieDetailsE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeToMovieDetailsE2ETests.swift; sourceTree = "<group>"; };
+		3F535AC92E7863E10020EA95 /* HomeViewModelDelegateSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelDelegateSpy.swift; sourceTree = "<group>"; };
+		3F535ACC2E7864060020EA95 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		3F601DDA2D3F15F8004F08AF /* CustomAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlert.swift; sourceTree = "<group>"; };
 		3F601DDD2D3F1D4C004F08AF /* DevelopmentServiceFactory.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevelopmentServiceFactory.swift.swift; sourceTree = "<group>"; };
 		3F601DDF2D3F1D57004F08AF /* ProductionServiceFactory.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionServiceFactory.swift.swift; sourceTree = "<group>"; };
@@ -214,6 +218,7 @@
 		3F535AB22E6A18B60020EA95 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				3F535AC82E7863D90020EA95 /* Home */,
 				3F535AB32E6A18C60020EA95 /* MovieDetails */,
 			);
 			path = Sources;
@@ -270,6 +275,23 @@
 				3F535AC42E785C6F0020EA95 /* SimilarMovieTableViewCellPage.swift */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		3F535AC82E7863D90020EA95 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				3F535AC92E7863E10020EA95 /* HomeViewModelDelegateSpy.swift */,
+				3F535ACB2E7863EB0020EA95 /* ViewModel */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		3F535ACB2E7863EB0020EA95 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				3F535ACC2E7864060020EA95 /* HomeViewModelTests.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		3F601DDC2D3F1D3A004F08AF /* ServiceFactories */ = {
@@ -754,6 +776,8 @@
 			files = (
 				3F535AB12E6A189C0020EA95 /* MovieDetailsViewModelTests.swift in Sources */,
 				3FD6285A2D3BE9420059116F /* MovieFinderTests.swift in Sources */,
+				3F535ACA2E7863E10020EA95 /* HomeViewModelDelegateSpy.swift in Sources */,
+				3F535ACD2E7864060020EA95 /* HomeViewModelTests.swift in Sources */,
 				3F535AB62E76FDC10020EA95 /* MovieDetailsViewModelDelegateSpy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MovieFinder/MovieFinder/Sources/Home/View/HomeVC.swift
+++ b/MovieFinder/MovieFinder/Sources/Home/View/HomeVC.swift
@@ -25,7 +25,7 @@ class HomeVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         screen?.delegate(delegate: self)
-        viewModel.delegate(delegate: self)
+        viewModel.delegate = self
         viewModel.setupTitles()
         setupNavigationBar()
         // Do any additional setup after loading the view.

--- a/MovieFinder/MovieFinder/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/MovieFinder/MovieFinder/Sources/Home/ViewModel/HomeViewModel.swift
@@ -11,26 +11,20 @@ protocol HomeViewModelDelegate: AnyObject {
     func setupTitles()
 }
 
-final class HomeViewModel {
+protocol HomeViewModelProtocol: AnyObject {
+    var delegate: HomeViewModelDelegate? { get set }
+    func setupTitles()
+}
+
+final class HomeViewModel: HomeViewModelProtocol {
     let welcomeLabelText = "home.description".localized
     let welcomeButtonTitle = "home.button.title".localized
     
-    private weak var delegate: HomeViewModelDelegate?
+    weak var delegate: HomeViewModelDelegate?
 }
 
 // MARK: - Functions
 extension HomeViewModel {
-    /// Sets the delegate for the HomeViewModel.
-    ///
-    /// - Parameter delegate: An optional object conforming to the `HomeViewModelDelegate` protocol.
-    public func delegate(delegate: HomeViewModelDelegate?) {
-        self.delegate = delegate
-    }
-    
-    /// Informs the delegate to set up titles.
-    ///
-    /// This method calls the `setupTitles` method on the delegate, allowing the delegate
-    /// to configure the titles in the UI.
     public func setupTitles() {
         delegate?.setupTitles()
     }

--- a/MovieFinder/MovieFinderTests/Sources/Home/HomeViewModelDelegateSpy.swift
+++ b/MovieFinder/MovieFinderTests/Sources/Home/HomeViewModelDelegateSpy.swift
@@ -1,0 +1,17 @@
+//
+//  HomeViewModelDelegateSpy.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+
+import XCTest
+@testable import MovieFinder
+
+class HomeViewModelDelegateSpy: HomeViewModelDelegate {
+    private(set) var setupTitlesCallCount = 0
+    
+    func setupTitles() {
+        setupTitlesCallCount += 1
+    }
+}

--- a/MovieFinder/MovieFinderTests/Sources/Home/ViewModel/HomeViewModelTests.swift
+++ b/MovieFinder/MovieFinderTests/Sources/Home/ViewModel/HomeViewModelTests.swift
@@ -1,0 +1,45 @@
+//
+//  HomeViewModelTests.swift
+//  MovieFinder
+//
+//  Created by Bruno Moura on 15/09/25.
+//
+
+import XCTest
+@testable import MovieFinder
+
+final class HomeViewModelTests: XCTestCase {
+    private var delegateSpy: HomeViewModelDelegateSpy!
+    private var sut: HomeViewModel!
+    
+    override func setUp() {
+        super.setUp()
+        delegateSpy = HomeViewModelDelegateSpy()
+        sut = HomeViewModel()
+        sut.delegate = delegateSpy
+    }
+    
+    override func tearDown() {
+        delegateSpy = nil
+        sut = nil
+        super.tearDown()
+    }
+    
+    func test_setupTitles_whenCalled_shouldCallDelegate() {
+        // Arrange
+        
+        // Act
+        sut.setupTitles()
+        
+        // Assert
+        XCTAssertEqual(delegateSpy.setupTitlesCallCount, 1)
+    }
+    
+    func test_welcomeLabelText_shouldReturnLocalizedValue() {
+        XCTAssertEqual(sut.welcomeLabelText, "home.description".localized)
+    }
+
+    func test_welcomeButtonTitle_shouldReturnLocalizedValue() {
+        XCTAssertEqual(sut.welcomeButtonTitle, "home.button.title".localized)
+    }
+}


### PR DESCRIPTION
- Add `HomeViewModelDelegateSpy` to mock delegate interactions.
- Validate that `setupTitles()` correctly forwards the call to the delegate.
- Ensure the app does not crash when calling the function with a nil delegate.